### PR TITLE
fixed issue with min_percent in interactive taxa plots

### DIFF
--- a/q2d2/markdown/biom-to-taxa-plots.md
+++ b/q2d2/markdown/biom-to-taxa-plots.md
@@ -15,5 +15,5 @@ Text describing workflow...
 ```python
 >>> %matplotlib inline
 >>> from q2d2.wui import interactive_plot_taxa_summary
->>> interactive_plot_taxa_summary(sample_md, table, taxa, min_percent=1)
+>>> interactive_plot_taxa_summary(sample_md, table)
 ```

--- a/q2d2/wui.py
+++ b/q2d2/wui.py
@@ -133,7 +133,7 @@ def get_taxa_counts(metadata_df, otu_df, category):
 
 def normalize(df):
     for col in df.columns:
-        normalized_col = df[col]/df[col].sum()
+        normalized_col = df[col]/df[col].sum()        
         df[col] = normalized_col
     return df
 

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,6 @@ setup(name='q2d2',
       package_data={'q2d2': ['q2d2/markdown/*md']},
       setup_requires=['numpy >= 1.9.2'],
       install_requires=[
-          'scikit-bio >= 0.4.0',
-          'IPython >= 3.2.0',
           'ipymd',
           'click',
           'seaborn'


### PR DESCRIPTION
I moved the functionality of the minimum percent in `interactive_plot_taxa_summary` from being a function parameter to being a widget.
